### PR TITLE
Adding new way to run project without helm

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -101,3 +101,38 @@ Uninstall the helm release using the delete command.
 ```bash
 helm delete external-secrets --namespace external-secrets
 ```
+## Alternative way to debug or build local changes faster
+There is an alternative for running the project in case of quick tests or to debug faster. In this case, there will be no need to install Helm to install all project configurations. 
+### Environment set-up
+First, you should raise a non-specific cluster, using kind or k3s. In this tutorial, it is used kind.
+Be sure that your kubectl is pointing to this kind. For this, you should have your kubeconfig configured correctly.A tip is to verify if the command:
+
+```bash
+kubectl get nodes
+```
+ returns the nodes.
+
+
+Then, install crds with:
+```bash
+kubectl apply -f deploy/crds/bundle.yaml
+```
+### Inserting SecretStore and ExternalSecret
+Apply any valid SecretStore and ExternalSecret. It recommended a valid SecretStore and ExternalSecret to avoid errors.
+### Debugging 
+To see how the project works with modifications, we recommend making your changes at: 
+```bash
+external-secrets/pkg/controllers/external secret/externalsecret_controller.go
+```
+and put log.info() or fmt.Println() to see the controller acting.
+Then run 
+```bash
+make run
+```
+or 
+```bash
+go run
+```
+Footer
+© 2023 GitHub, Inc.
+Footer navigation

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -133,6 +133,7 @@ or
 ```bash
 go run
 ```
+
 Footer
 © 2023 GitHub, Inc.
 Footer navigation


### PR DESCRIPTION
Problem Statement
Dificulty to monitor simultaneously the local changes while debugging

Related Issue
Fixes #2753

Proposed Changes
An alternative method for running the project, without needing to install Helm for all project configurations, as an approach for quick tests or faster debugging. 

Checklist
[X] I have read the contribution guidelines
[X] All commits are signed with git commit --signoff
[X] My changes have reasonable test coverage
[X] All tests pass with make test
[X] I ensured my PR is ready for review with make reviewable 
